### PR TITLE
Use timeout for overflow tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,15 +24,7 @@ for INPUT in 234587234857293847582834 4294967296 6442450943; do
     echo "TEST: Overflow returns exit status 2"
     # NOTE: Incorrect processing of overflow inputs could cause a very
     # long sleep!  Set a timeout on these test cases.
-    (
-        sleep 12
-        PROCS="`ps`"
-        if echo "$PROCS" | grep nap-x86-64 >/dev/null; then
-            echo 'Timeout!'
-            killall nap-x86-64
-        fi
-    ) &
-    ./out/nap-x86-64 $INPUT 1>/dev/null 2>/dev/null
+    timeout 12s ./out/nap-x86-64 "$INPUT" 1>/dev/null 2>/dev/null
     EXIT_CODE=$?
     if [[ "$EXIT_CODE" != "2" ]]; then
         STATUS="FAIL"
@@ -40,8 +32,6 @@ for INPUT in 234587234857293847582834 4294967296 6442450943; do
     else
         echo "PASSED"
     fi
-    kill %1 # Terminate the timeout job.
-    wait # Reap the exit status before continuing.
 done
 
 #


### PR DESCRIPTION
## Summary
- simplify overflow input test by replacing manual background process with `timeout`

## Testing
- `scripts/build.sh` *(fails: aarch64 cross tools missing)*
- `bash scripts/test.sh` *(fails: segmentation fault from nap binary)*

------
https://chatgpt.com/codex/tasks/task_b_689d0520272c83258bfb0af4b54887f3