### PR TITLE
chore(ci): update checkout action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- use latest checkout action in CI workflow

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*
- `make ci_tests` *(fails: `aarch64-linux-gnu-as` No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689dd13e40608325b32e64f8efc2cce4